### PR TITLE
Replacing fog with AWS SDK

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,7 @@ suites:
         aws_access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
         aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
         aws_session_token: <%= ENV['AWS_SESSION_TOKEN'] %>
+        region: 'us-east-1'
       records:
         generic_record:
           name: 'kitchen-test.yourdomain.org'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v0.5.0
+* Change provider to use the AWS SDK v2 gem instead of fog
 ## v0.4.2
 * fix the provider to correctly identify existing records
 ## v0.4.0

--- a/Cheffile
+++ b/Cheffile
@@ -4,5 +4,3 @@ site 'https://supermarket.getchef.com/api/v1'
 
 cookbook 'route53', path: '.'
 cookbook 'route53_test', path: './test/integration/cookbooks/route53_test'
-
-cookbook 'xml'

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ route53_record "create a record" do
   value "16.8.4.2"
   type  "A"
   zone_id               node[:route53][:zone_id]
-  aws_access_key_id     node[:route53][:aws_access_key_id]
-  aws_secret_access_key node[:route53][:aws_secret_access_key]
   overwrite true
   action :create
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,1 @@
-default['route53']['fog_version'] = '1.27'
+default['route53']['aws_sdk_version'] = '2.0.46'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,4 @@ maintainer_email "support@hw-ops.com"
 license          "Apache 2.0"
 description      "Installs/Configures route53"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.4.2"
-
-depends 'xml'
+version          "0.5.0"

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -1,158 +1,63 @@
-def aws
-  {
-  :provider => 'AWS',
-  :aws_access_key_id => new_resource.aws_access_key_id,
-  :aws_secret_access_key => new_resource.aws_secret_access_key,
-  :aws_session_token => new_resource.aws_session_token
-  }
-end
-
-def name
-  @name ||= begin
-    return new_resource.name + '.' if new_resource.name !~ /\.$/
-    new_resource.name
-  end
-end
-
-def value
-  @value ||= Array(new_resource.value)
-end
-
-def type
-  @type ||= new_resource.type
-end
-
-def ttl
-  @ttl ||= new_resource.ttl
-end
-
-def overwrite
-  @overwrite ||= new_resource.overwrite
-end
-
-def alias_target
-  @alias_target ||= new_resource.alias_target
-end
-
-def mock?
-  @mock ||= new_resource.mock
-end
-
-def mock_env(connection_info)
-  Fog.mock!
-  conn = Fog::DNS.new(connection_info)
-  zone_id = conn.create_hosted_zone(name).body['HostedZone']['Id']
-  conn.zones.get(zone_id)
-end
-
-def zone(connection_info)
-  @zone ||= begin
-    if mock?
-      @zone = mock_env(connection_info)
-    elsif new_resource.aws_access_key_id && new_resource.aws_secret_access_key
-      @zone = Fog::DNS.new(connection_info).zones.get( new_resource.zone_id )
-    else
-      Chef::Log.info "No AWS credentials supplied, going to attempt to use IAM roles instead"
-      @zone = Fog::DNS.new({ :provider => "AWS", :use_iam_profile => true }
-                             ).zones.get( new_resource.zone_id )
-    end
-  end
-end
-
-def record_attributes
-  common_attributes = { :name => name, :type => type }
-  common_attributes.merge(record_value_or_alias_attributes)
-end
-
-def record
-  Chef::Log.info("Getting record: #{name} #{type}")
-  records = zone(aws).records
-  records.count.zero? ? nil : records.get(name, type)
-end
-
-def record_value_or_alias_attributes
-  if alias_target
-    { :alias_target => alias_target.to_hash }
-  else
-    { :value => value, :ttl => ttl }
-  end
-end
-
 action :create do
-  require 'fog'
-  require 'nokogiri'
+  require 'aws-sdk-core'
 
-  def create
-    begin
-      zone(aws).records.create(record_attributes)
-      Chef::Log.debug("Created record: #{record_attributes.inspect}")
-    rescue Excon::Errors::BadRequest => e
-      Chef::Log.error Nokogiri::XML( e.response.body ).xpath( "//xmlns:Message" ).text
-    end
-  end
+  @zones = { 'A' => 'Z38ROTMZFQYWIJ', 'PTR' => 'Z1U3P2W8H9ACLE', 'CNAME' => 'Z38ROTMZFQYWIJ' }
+  @region = 'us-east-1'
+  @domain = 'optimizely'
+  @vpc_id = 'vpc-18b7407d'
 
-  def same_record?(record)
-    name.chomp(".").eql?(record.name.chomp(".")) &&
-      same_value?(record) &&
-        ttl.eql?(record.ttl.to_i)
-  end
-
-  def same_value?(record)
-    if alias_target
-      same_alias_target?(record)
-    else
-      value.sort == record.value.sort
-    end
-  end
-
-  def same_alias_target?(record)
-    alias_target &&
-      record.alias_target &&
-      (alias_target['dns_name'] == record.alias_target['DNSName'].gsub(/\.$/,''))
-  end
-
-  if record.nil?
-    create
-    Chef::Log.info "Record created: #{name}"
-  elsif !same_record?(record)
-    if overwrite
-      record.destroy
-      create
-      Chef::Log.info "Record modified: #{name}"
-    else
-      Chef::Log.info "Record #{name} should have been modified, but overwrite is set to false."
-      Chef::Log.debug "Current value: #{record.value.first}"
-      Chef::Log.debug "Desired value: #{value}"
-    end
-  else Chef::Log.info "There is nothing to update."
-  end
-end
-
-action :delete do
-  require 'fog'
-  require 'nokogiri'
-
-  if mock?
-    # Make some fake data so that we can successfully delete when testing.
-    zone(aws).records.create(
-      name: name,
-      type: type,
-      value: ['1.2.3.4'],
-      ttyl: 300
+  def create_record(name, value, record_type, ttl)
+    @route53 ||= Aws::Route53::Client.new(region: @region)
+    Chef::Log.debug "Record for #{name} to #{value} of type #{record_type}"
+    @route53.change_resource_record_sets(
+      hosted_zone_id: new_resource.zone_id || @zones[record_type],
+      change_batch: {
+        changes: [
+          {
+            action: 'UPSERT',
+            resource_record_set: {
+              name: name.strip,
+              type: record_type,
+              ttl: ttl,
+              resource_records: [{ value: value.strip }],
+            },
+          },
+        ],
+      },
     )
   end
 
-  def delete
-    zone(aws).records.get(name, type).destroy
-    Chef::Log.debug("Destroyed record: #{name} #{type}")
-  rescue Excon::Errors::BadRequest => e
-    Chef::Log.error Nokogiri::XML(e.response.body).xpath('//xmlns:Message').text
+  create_record(new_resource.name, new_resource.value, new_resource.type, new_resource.ttl)
+end
+
+action :delete do
+  require 'aws-sdk-core'
+
+  @zones = { 'A' => 'Z38ROTMZFQYWIJ', 'PTR' => 'Z1U3P2W8H9ACLE', 'CNAME' => 'Z38ROTMZFQYWIJ' }
+  @region = 'us-east-1'
+  @domain = 'optimizely'
+  @vpc_id = 'vpc-18b7407d'
+
+  def delete_record(name, value, record_type, ttl)
+    @route53 ||= Aws::Route53::Client.new(region: @region)
+    Chef::Log.debug "Deleting record for #{name} of type #{record_type}"
+    @route53.change_resource_record_sets(
+      hosted_zone_id: new_resource.zone_id || @zones[record_type],
+      change_batch: {
+        changes: [
+          {
+            action: 'DELETE',
+            resource_record_set: {
+              name: name.strip,
+              type: record_type,
+              ttl: ttl,
+              resource_records: [{ value: value.strip }],
+            },
+          },
+        ],
+      },
+    )
   end
 
-  if record.nil?
-    Chef::Log.info 'There is nothing to delete.'
-  else
-    delete
-    Chef::Log.info "Record deleted: #{name}"
-  end
+  delete_record(new_resource.name, new_resource.value, new_resource.type, new_resource.ttl)
 end

--- a/providers/record.rb
+++ b/providers/record.rb
@@ -1,16 +1,11 @@
 action :create do
   require 'aws-sdk-core'
 
-  @zones = { 'A' => 'Z38ROTMZFQYWIJ', 'PTR' => 'Z1U3P2W8H9ACLE', 'CNAME' => 'Z38ROTMZFQYWIJ' }
-  @region = 'us-east-1'
-  @domain = 'optimizely'
-  @vpc_id = 'vpc-18b7407d'
-
-  def create_record(name, value, record_type, ttl)
-    @route53 ||= Aws::Route53::Client.new(region: @region)
+  def create_record(name, value, region, zone_id, record_type, ttl)
+    @route53 ||= Aws::Route53::Client.new(region: region)
     Chef::Log.debug "Record for #{name} to #{value} of type #{record_type}"
     @route53.change_resource_record_sets(
-      hosted_zone_id: new_resource.zone_id || @zones[record_type],
+      hosted_zone_id: zone_id,
       change_batch: {
         changes: [
           {
@@ -27,22 +22,17 @@ action :create do
     )
   end
 
-  create_record(new_resource.name, new_resource.value, new_resource.type, new_resource.ttl)
+  create_record(new_resource.name, new_resource.value, new_resource.region, new_resource.zone_id, new_resource.type, new_resource.ttl)
 end
 
 action :delete do
   require 'aws-sdk-core'
 
-  @zones = { 'A' => 'Z38ROTMZFQYWIJ', 'PTR' => 'Z1U3P2W8H9ACLE', 'CNAME' => 'Z38ROTMZFQYWIJ' }
-  @region = 'us-east-1'
-  @domain = 'optimizely'
-  @vpc_id = 'vpc-18b7407d'
-
-  def delete_record(name, value, record_type, ttl)
-    @route53 ||= Aws::Route53::Client.new(region: @region)
+  def delete_record(name, value, region, zone_id, record_type, ttl)
+    @route53 ||= Aws::Route53::Client.new(region: region)
     Chef::Log.debug "Deleting record for #{name} of type #{record_type}"
     @route53.change_resource_record_sets(
-      hosted_zone_id: new_resource.zone_id || @zones[record_type],
+      hosted_zone_id: zone_id,
       change_batch: {
         changes: [
           {
@@ -59,5 +49,5 @@ action :delete do
     )
   end
 
-  delete_record(new_resource.name, new_resource.value, new_resource.type, new_resource.ttl)
+  delete_record(new_resource.name, new_resource.value, new_resource.region, new_resource.zone_id, new_resource.type, new_resource.ttl)
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,13 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-include_recipe 'xml::ruby'
-
-chef_gem "fog" do
+chef_gem "aws-sdk-core" do
   compile_time false
   action :install
-  version node['route53']['fog_version']
+  version node['route53']['aws_sdk_version']
 end
 
 require 'rubygems'

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -7,9 +7,3 @@ attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :zone_id,               :kind_of => String
-attribute :aws_access_key_id,     :kind_of => String
-attribute :aws_secret_access_key, :kind_of => String
-attribute :aws_session_token,     :kind_of => String
-attribute :overwrite,             :kind_of => [ TrueClass, FalseClass ], :default => true
-attribute :alias_target,          :kind_of => Hash
-attribute :mock,                  kind_of: [TrueClass, FalseClass], default: false

--- a/resources/record.rb
+++ b/resources/record.rb
@@ -7,3 +7,4 @@ attribute :value,                 :kind_of => [ String, Array ]
 attribute :type,                  :kind_of => String, :required => true
 attribute :ttl,                   :kind_of => Integer, :default => 3600
 attribute :zone_id,               :kind_of => String
+attribute :region,                :kind_of => String

--- a/spec/default/default_spec.rb
+++ b/spec/default/default_spec.rb
@@ -1,25 +1,5 @@
 require 'spec_helper'
 
-describe package('build-essential') do
-  it { should be_installed }
-end
-
-describe package('libxml-dev'), :if => os[:family] == 'debian' do
-  it { should be_installed }
-end
-
-describe package('libxslt1-dev'), :if => os[:family] == 'debian' do
-  it { should be_installed }
-end
-
-describe package('libxml-devel'), :if => os[:family] == 'rhel' do
-  it { should be_installed }
-end
-
-describe package('libxslt1-devel'), :if => os[:family] == 'debian' do
-  it { should be_installed }
-end
-
-describe package('fog') do
+describe package('aws-sdk-core') do
   it { should be_installed.by('gem') }
 end

--- a/test/integration/cookbooks/route53_test/metadata.rb
+++ b/test/integration/cookbooks/route53_test/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'aaron@hw-ops.com'
 license          'Apache 2.0'
 description      'Installs/Configures route53_wrapper test cookbook'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends 'route53'

--- a/test/integration/cookbooks/route53_test/recipes/default.rb
+++ b/test/integration/cookbooks/route53_test/recipes/default.rb
@@ -38,20 +38,13 @@ route53_record node[:records][:generic_record][:name] do
   type                  node[:records][:generic_record][:type]
   ttl                   node[:records][:generic_record][:ttl]
   zone_id               node[:route53][:zone_id]
-  aws_access_key_id     node[:route53][:aws_access_key_id]
-  aws_secret_access_key node[:route53][:aws_secret_access_key]
-  overwrite             true
   action                :create
   mock                  true
 end
 
 route53_record node[:records][:alias_record][:name] do
-  alias_target          node[:records][:alias_record][:alias_target]
   type                  node[:records][:alias_record][:type]
   zone_id               node[:route53][:zone_id]
-  aws_access_key_id     node[:route53][:aws_access_key_id]
-  aws_secret_access_key node[:route53][:aws_secret_access_key]
-  overwrite             true
   action                :create
   only_if               { node[:records][:alias_record][:run] }
   mock                  true
@@ -61,8 +54,6 @@ route53_record "#{node[:records][:generic_record][:name]}_delete" do
   name                  node[:records][:generic_record][:name]
   type                  node[:records][:generic_record][:type]
   zone_id               node[:route53][:zone_id]
-  aws_access_key_id     node[:route53][:aws_access_key_id]
-  aws_secret_access_key node[:route53][:aws_secret_access_key]
   action                :delete
   mock                  true
 end

--- a/test/integration/cookbooks/route53_test/recipes/default.rb
+++ b/test/integration/cookbooks/route53_test/recipes/default.rb
@@ -37,23 +37,25 @@ route53_record node[:records][:generic_record][:name] do
   value                 node[:records][:generic_record][:value]
   type                  node[:records][:generic_record][:type]
   ttl                   node[:records][:generic_record][:ttl]
+  region                node[:route53][:region]
   zone_id               node[:route53][:zone_id]
   action                :create
-  mock                  true
 end
 
 route53_record node[:records][:alias_record][:name] do
   type                  node[:records][:alias_record][:type]
   zone_id               node[:route53][:zone_id]
+  ttl                   node[:records][:generic_record][:ttl]
+  region                node[:route53][:region]
   action                :create
   only_if               { node[:records][:alias_record][:run] }
-  mock                  true
 end
 
 route53_record "#{node[:records][:generic_record][:name]}_delete" do
   name                  node[:records][:generic_record][:name]
   type                  node[:records][:generic_record][:type]
   zone_id               node[:route53][:zone_id]
+  ttl                   node[:records][:generic_record][:ttl]
+  region                node[:route53][:region]
   action                :delete
-  mock                  true
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,25 +1,5 @@
 require 'spec_helper'
 
-describe package('build-essential') do
-  it { should be_installed }
-end
-
-describe package('libxml2-dev'), :if => os[:family] == 'ubuntu' do
-  it { should be_installed }
-end
-
-describe package('libxslt1-dev'), :if => os[:family] == 'ubuntu' do
-  it { should be_installed }
-end
-
-describe package('libxml2-devel'), :if => os[:family] == 'rhel' do
-  it { should be_installed }
-end
-
-describe package('libxslt1-devel'), :if => os[:family] == 'rhel' do
-  it { should be_installed }
-end
-
 describe command('/opt/chef/embedded/bin/gem list') do
-  its(:stdout) { should match /fog/ }
+  its(:stdout) { should match /aws-sdk-core/ }
 end


### PR DESCRIPTION
@optimizely/data-services 

This change replaces fog in the Route 53 cookbook with the actual AWS API. Should make things easier to use/debug.

For testing, I actually copied over the cookbook to one of the Kafka hosts that was failing Chef runs and ran it.
